### PR TITLE
Update escapeTable to escape the value itself (not just adding quotes)

### DIFF
--- a/library/Basic/Database.php
+++ b/library/Basic/Database.php
@@ -77,9 +77,11 @@ class Basic_Database extends PDO
 	{
 		switch (Basic::$database->getAttribute(PDO::ATTR_DRIVER_NAME))
 		{
-			case 'sqlite':
-			case 'pgsql':	return '"'. $name .'"';
-			case 'mysql':	return '`'. $name .'`';
+			case 'sqlite': // "A keyword in double-quotes is an identifier" - https://www.sqlite.org/lang_keywords.html
+			case 'pgsql':  // "The delimited identifier [uses] double-quotes"; "To include a double quote, write two double quotes" - https://www.postgresql.org/docs/current/sql-syntax-lexical.html
+				return '"'. str_replace('"', '""', $name) .'"';
+			case 'mysql': // "The identifier quote character is the backtick"; to use the backtick, "double the character" - https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+				return '`' . str_replace('`', '``', $name) . '`';
 			default:		throw new Basic_Exception("Unsupported PDO driver %s", [Basic::$database->getAttribute(PDO::ATTR_DRIVER_NAME)]);
 		}
 	}


### PR DESCRIPTION
While we would ideally use `pg_escape_identifier()`, this framework uses PDO, so there is no `PgSql\Connection` to use.

But the PostgreSQL documentation does say "[To include a double quote, write two double quotes](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)".

Likewise with MySQL, you can "[double the [backtick] character](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html)"

The sqlite documentation seems to be less clear, it confirms that "[a keyword in double-quotes is an identifier](https://www.sqlite.org/lang_keywords.html)", but I can only find mention that single quotes (for a literal) "[are escaped by putting two single quotes in a row](https://www.sqlite.org/faq.html#q14)".

---

Geeky details... it is possible to check the PHP and PostgreSQL source:

- `pg_escape_identifier()` calls `php_pgsql_escape_internal()`, [on lines 3294 - 3298](https://github.com/php/php-src/blob/375e7402afdd324194bbecc769ca6982e3a8af05/ext/pgsql/pgsql.c#L3294-L3298);
-  Which in turn calls `PQescapeIdentifier`, [on line 3274](https://github.com/php/php-src/blob/375e7402afdd324194bbecc769ca6982e3a8af05/ext/pgsql/pgsql.c#L3274).
- This is defined in `libpq` (PostgreSQL) `fe-exec.c`, on [line 4143](https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/interfaces/libpq/fe-exec.c;h=ec62550e3858135a48be0489df51883c0f9b25ca;hb=HEAD#l4143);
- Which calls `PQescapeInternal`, on [lines 4015 - 4134](https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/interfaces/libpq/fe-exec.c;h=ec62550e3858135a48be0489df51883c0f9b25ca;hb=HEAD#l4015).

Where you can see:

- The `quote_char` gets set to `"` (line 4024);
- The `num_quotes` is incremented (line 4037), to determine the new `rp` string size;
- The "Opening quote" `quote_char` is added (line 4085);
- Then any time `quote_char` is found, it uses `*rp++ = *s;` twice (lines 4109 to 4110);
- Then we finish by adding a final `quote_char` and terminating NUL (lines 4130 to 4131).