### PR TITLE
Support literal-string in Database:q(), with Identifiers

### DIFF
--- a/library/Basic/Database.php
+++ b/library/Basic/Database.php
@@ -30,12 +30,15 @@ class Basic_Database extends PDO
 	/**
 	 * Combine prepare & execute providing a single method to pass both the query and parameters
 	 *
-	 * @param string $query Sql query to execute
+	 * @param literal-string $query Sql query to execute
 	 * @param array $parameters Sql parameters for the query
 	 * @return Basic_DatabaseQuery
 	 */
-	public function q(string $query, array $parameters = []): Basic_DatabaseQuery
+	public function q(string $query, array $parameters = [], array $identifiers = []): Basic_DatabaseQuery
 	{
+		foreach ($identifiers as $name => $value) {
+			$query = str_replace('{' . $name . '}', self::escapeTable($value), $query);
+		}
 		try
 		{
 			$statement = $this->prepare($query);


### PR DESCRIPTION
Support an array of `$identifiers`, which are escaped with `escapeTable()` (which also works with field names).

This allows the `$query` SQL to be defined as a `literal-string` ([psalm](https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#literal-string)/[phpStan](https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types))

It is rare to need this (normally you would expect things like the `ORDER BY` to use a limited set of options, if you want a user-defined field to be accepted you can use this and have the value escaped correctly.

```php
Basic::$database->q('... WHERE id = ? ORDER BY {f}', [$id], ['f' => $field]);
```